### PR TITLE
Update petsc solver

### DIFF
--- a/RAPIDpy/rapid.py
+++ b/RAPIDpy/rapid.py
@@ -774,18 +774,16 @@ class RAPID(object):
         log("Running RAPID ...",
             "INFO")
         if os.name == "nt":
-            local_rapid_executable_location = \
-                self._get_cygwin_path(local_rapid_executable_location)
+            local_rapid_executable_location = self._get_cygwin_path(local_rapid_executable_location)
 
         # htcondor will not allow mpiexec for single processor jobs
         # this was added for that purpose
-        run_rapid_command = [local_rapid_executable_location,
-                             "-ksp_type", self._ksp_type]
+        run_rapid_command = [local_rapid_executable_location, "-ksp_type", 'preonly']
 
-        if self._num_processors > 1:
-            run_rapid_command = [self._mpiexec_command,
-                                 "-n", str(self._num_processors)] \
-                                + run_rapid_command
+        # if self._num_processors > 1:
+        #     run_rapid_command = [self._mpiexec_command,
+        #                          "-n", str(self._num_processors)] \
+        #                         + run_rapid_command
 
         process = Popen(run_rapid_command,
                         stdout=PIPE, stderr=PIPE, shell=False)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='RAPIDpy',
-    version='2.7.0',
+    version='2.8.0',
     description='Python interface for RAPID (rapid-hub.org)',
     long_description='RAPIDpy is a python interface for RAPID that assists '
          'to prepare inputs, runs the RAPID program, and provides '

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ setup(
         'Intended Audience :: Science/Research',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Remove usages of MPI and use the PETSc preonly solver insetad of richardson

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the command construction logic in the RAPIDpy cleanup process for efficiency.
- **Chores**
	- Updated RAPIDpy package version to 2.8.0.
	- Removed Python 2 support indicators from the package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->